### PR TITLE
golang.bbclass: restore compatibility with krogoth

### DIFF
--- a/classes/golang.bbclass
+++ b/classes/golang.bbclass
@@ -1,7 +1,7 @@
 inherit golang-osarchmap ptest
 
 def get_go_parallel_make(d):
-    pm = (d.getVar('PARALLEL_MAKE') or '').split()
+    pm = (d.getVar('PARALLEL_MAKE', True) or '').split()
     # look for '-j' and throw other options (e.g. '-l') away
     # because they might have a different meaning in golang
     while pm:


### PR DESCRIPTION
Commit 1a6634 worked for pyro but not for krogoth due to the changed
behaviour of getVar.

Signed-off-by: Andreas Oberritter <obi@opendreambox.org>

---
I know there's a separate branch for krogoth, but we're using meta-golang/master, due to the lack of mips32 support in older golang.
All other occurrences of getVar in meta-golang use the compatible syntax, too.